### PR TITLE
fix: reshape pred and target in cross entropy loss computation

### DIFF
--- a/models/attention_rnn.py
+++ b/models/attention_rnn.py
@@ -79,8 +79,9 @@ class DeepBeatsAttentionRNN(nn.Module):
 
     def loss_function(self, pred, target):
         criterion = nn.CrossEntropyLoss()
-        target_one_hot = torch.nn.functional.one_hot(target, self.num_notes).float()
-        loss = criterion(pred, target_one_hot)
+        target = target.flatten() # (batch_size * seq_len)
+        pred = pred.reshape(-1, pred.shape[-1]) # (batch_size * seq_len, num_notes)
+        loss = criterion(pred, target)
         return loss
 
     def clip_gradients_(self, max_value):

--- a/models/bi_lstm.py
+++ b/models/bi_lstm.py
@@ -17,5 +17,7 @@ class DeepBeatsBiLSTM(nn.Module):
 
     def loss_function(self, pred, target):
         criterion = nn.CrossEntropyLoss()
+        target = target.flatten() # (batch_size * seq_len)
+        pred = pred.reshape(-1, pred.shape[-1]) # (batch_size * seq_len, num_notes)
         loss = criterion(pred, target)
         return loss

--- a/models/lstm.py
+++ b/models/lstm.py
@@ -65,8 +65,9 @@ class DeepBeatsLSTM(nn.Module):
         Target: (batch_size, seq_len), range from 0 to num_notes-1
         """
         criterion = nn.CrossEntropyLoss()
-        target_one_hot = torch.nn.functional.one_hot(target, self.num_notes).float()
-        loss = criterion(pred, target_one_hot)
+        target = target.flatten() # (batch_size * seq_len)
+        pred = pred.reshape(-1, pred.shape[-1]) # (batch_size * seq_len, num_notes)
+        loss = criterion(pred, target)
         return loss
     
     def clip_gradients_(self, max_value):

--- a/models/lstm_local_attn.py
+++ b/models/lstm_local_attn.py
@@ -103,8 +103,9 @@ class DeepBeatsLSTMLocalAttn(nn.Module):
         Target: (batch_size, seq_len), range from 0 to num_notes-1
         """
         criterion = nn.CrossEntropyLoss()
-        target_one_hot = torch.nn.functional.one_hot(target, self.num_notes).float()
-        loss = criterion(pred, target_one_hot)
+        target = target.flatten() # (batch_size * seq_len)
+        pred = pred.reshape(-1, pred.shape[-1]) # (batch_size * seq_len, num_notes)
+        loss = criterion(pred, target)
         return loss
 
     def clip_gradients_(self, max_value):

--- a/models/transformer.py
+++ b/models/transformer.py
@@ -99,8 +99,9 @@ class DeepBeatsTransformer(nn.Transformer):
         """
         target = target.transpose(1, 0)
         criterion = nn.CrossEntropyLoss()
-        target_one_hot = torch.nn.functional.one_hot(target, self.num_notes).float()
-        loss = criterion(pred, target_one_hot)
+        target = target.flatten() # (batch_size * seq_len)
+        pred = pred.reshape(-1, pred.shape[-1]) # (batch_size * seq_len, num_notes)
+        loss = criterion(pred, target)
         return loss
 
     def clip_gradients_(self, max_value):

--- a/models/vanilla_rnn.py
+++ b/models/vanilla_rnn.py
@@ -67,8 +67,9 @@ class DeepBeatsVanillaRNN(nn.Module):
 
     def loss_function(self, pred, target):
         criterion = nn.CrossEntropyLoss()
-        target_one_hot = torch.nn.functional.one_hot(target, self.num_notes).float()
-        loss = criterion(pred, target_one_hot)
+        target = target.flatten() # (batch_size * seq_len)
+        pred = pred.reshape(-1, pred.shape[-1]) # (batch_size * seq_len, num_notes)
+        loss = criterion(pred, target)
         return loss
 
     def clip_gradients_(self, max_value):


### PR DESCRIPTION
Reshaped pred to be (N, C) and target to be (N) according to https://pytorch.org/docs/stable/generated/torch.nn.CrossEntropyLoss.html